### PR TITLE
Added feature to refresh lock screen on OSX 10.10

### DIFF
--- a/lib/desktop/osx/osx.rb
+++ b/lib/desktop/osx/osx.rb
@@ -34,6 +34,7 @@ module Desktop
       write_default_desktop image
       clear_custom_desktop_image unless skip_database
       touch_desktop_image
+      remove_cached_desktop_png
       reload_desktop unless skip_reload
     rescue Errno::EACCES => e
       raise DesktopImagePermissionsError.new(e)
@@ -77,8 +78,18 @@ module Desktop
       end
     end
 
+    def remove_cached_desktop_png
+      if File.file? default_cached_desktop_path
+        system("sudo rm -rf #{default_cached_desktop_path}")
+      end
+    end
+
     def reload_desktop
       system 'killall Dock'
+    end
+
+    def default_cached_desktop_path
+      '/Library/Caches/com.apple.desktop.admin.png'
     end
 
     def default_desktop_image_path

--- a/test/desktop/osx/osx_test.rb
+++ b/test/desktop/osx/osx_test.rb
@@ -14,6 +14,12 @@ module Desktop
         :skip_database      => true
       )
 
+      # stub out default_cache_path so system is modified during tests
+      def osx.default_cached_desktop_path
+        cache   = Tempfile.new(%w[cache .png])
+        cache.path
+      end
+
       yield osx, desktop, image
     ensure
       desktop.unlink
@@ -35,6 +41,17 @@ module Desktop
         osx do |osx, _, _|
           assert_raises OSX::DesktopImageMissingError do
             osx.desktop_image = LocalImage.new('/invalid/image/path.jpg')
+          end
+        end
+      end
+
+      it 'ensure clean up cache admin png' do
+        osx do |osx, desktop, image|
+          assert_equal File.file?(osx.default_cached_desktop_path), true
+
+          assert_send [osx, :remove_cached_desktop_png] do
+            osx.desktop_image = LocalImage.new(image)
+            assert_equal File.file?(osx.default_cached_desktop_path), false
           end
         end
       end


### PR DESCRIPTION
Hi @chrishunt I had just stumbled upon your podcast (via Smashing Robots) and heard about this little gem which works like a charm.
#### What's this PR do?

On Mac 10.10 (Yosemite) there is a blurred version of the wallpaper set for the login/lock screen but these were not getting updated through the `desktop set <filename>` command. I have added a step that removes this cache file so the next time the lock/login screen are visited the `png` will be regenerated from the new wallpaper.

Please feel free to double check but this should not cause any backwards compatibility issues as I check for the cache files existence before removing it.
#### Where should the reviewer start?

Changes only in ' lib/desktop/osx/osx.rb` and corresponding test file
#### How should this be manually tested?

Find yourself a yosemite machine `desktop set <something-great>` then lock or logout the machine.
#### Screenshots (if appropriate)

Screen in question
![Uploading image.png . . .]()
#### Questions:
- Does this add new dependencies into the application? **Nope**
