### PR TITLE
Support El Capitan

### DIFF
--- a/lib/desktop/cli.rb
+++ b/lib/desktop/cli.rb
@@ -15,22 +15,14 @@ module Desktop
       > $ desktop set http://url.to/image.jpg
     LONGDESC
     option :desktop_image_path, :hide => true
-    option :cached_image_path, :hide => true
     option :skip_reload, :type => :boolean, :hide => true
     option :skip_database, :type => :boolean, :hide => true
-    def set(path, already_failed = false)
+    def set(path)
       osx = OSX.new(options)
       image = HTTP.uri?(path) ? WebImage.new(path) : LocalImage.new(path)
 
       begin
         osx.desktop_image = image
-      rescue OSX::DesktopImagePermissionsError => e
-        fail_with_permissions_error if already_failed
-
-        print_permissions_message
-        osx.update_desktop_image_permissions
-        puts
-        set path, true
       rescue OSX::DesktopImageMissingError
         fail_with_missing_image_error image
       end
@@ -43,41 +35,15 @@ module Desktop
 
     private
 
-    def fail_with_permissions_error
-      print "Sorry, but I was unable to change your desktop image. "
-      puts  "The permissions are still incorrect."
-      puts
-      puts  "Did you type your password incorrectly?"
-      puts
-      print_issues_message
-      abort
-    end
-
     def fail_with_missing_image_error(image)
       puts "Sorry, but it looks like the image you provided does not exist:"
       puts
       puts image.path
       puts
-      print_issues_message
-      abort
-    end
-
-    def print_permissions_message
-      print "It looks like this is the first time you've tried to change "
-      puts  "your desktop."
-      puts
-      print "We need to make your desktop image writable before we can "
-      puts  "change it. This only needs to be done once."
-      puts
-      puts  "$ #{OSX.chown_command}"
-      puts  "$ #{OSX.chmod_command}"
-      puts
-    end
-
-    def print_issues_message
       puts "Please create an issue if you think this is my fault:"
       puts
       puts "https://github.com/chrishunt/desktop/issues/new"
+      abort
     end
   end
 end

--- a/lib/desktop/osx/database.rb
+++ b/lib/desktop/osx/database.rb
@@ -10,7 +10,13 @@ module Desktop
       end
 
       def clear_desktop_image
-        clear_data if data?
+        clear if data?
+      end
+
+      def set_desktop_image(desktop_image_path)
+        create unless data?
+
+        ([desktop_image_path] * 100).each { |path| insert(path) }
       end
 
       def close
@@ -25,9 +31,18 @@ module Desktop
         ).any?
       end
 
-      def clear_data
+      def insert(data)
+        connection.execute 'INSERT INTO data (value) VALUES (?)', data
+      end
+
+      def clear
         connection.execute 'DELETE FROM data'
         connection.execute 'VACUUM data'
+      end
+
+      def create
+        connection.execute 'CREATE TABLE data (value)'
+        connection.execute 'CREATE INDEX data_index ON data (value)'
       end
 
       def default_connection

--- a/lib/desktop/osx/osx.rb
+++ b/lib/desktop/osx/osx.rb
@@ -2,23 +2,10 @@ require 'desktop/osx/database'
 
 module Desktop
   class OSX
-    class DesktopImagePermissionsError < StandardError; end
     class DesktopImageMissingError < StandardError; end
 
     def self.desktop_image=(image)
       self.new.desktop_image = image
-    end
-
-    def self.update_desktop_image_permissions
-      self.new.update_desktop_image_permissions
-    end
-
-    def self.chown_command
-      self.new.chown_command
-    end
-
-    def self.chmod_command
-      self.new.chmod_command
     end
 
     def initialize(options = nil)
@@ -27,77 +14,41 @@ module Desktop
       @skip_database = options[:skip_database]
       @desktop_image_path = \
         options[:desktop_image_path] || default_desktop_image_path
-      @cached_image_path = \
-        options[:cached_image_path] || default_cached_image_path
     end
 
     def desktop_image=(image)
-      write_default_desktop image
-      clear_custom_desktop_image unless skip_database
-      touch_desktop_image
-      remove_cached_image
+      write_desktop image
+      save_image_path_in_database unless skip_database
       reload_desktop unless skip_reload
-    rescue Errno::EACCES => e
-      raise DesktopImagePermissionsError.new(e)
     rescue Errno::ENOENT => e
       raise DesktopImageMissingError.new(e)
-    end
-
-    def update_desktop_image_permissions
-      system(chown_command) && system(chmod_command)
-    end
-
-    def chown_command
-      [' -h ', ' '].map do |option|
-        "sudo chown#{option}$('whoami'):staff #{desktop_image_path}"
-      end.join(" && ")
-    end
-
-    def chmod_command
-      [' -h ', ' '].map do |option|
-        "sudo chmod#{option}664 #{desktop_image_path}"
-      end.join(" && ")
     end
 
     private
 
     attr_reader :desktop_image_path,
-                :cached_image_path,
                 :skip_reload,
                 :skip_database
 
-    def write_default_desktop(image)
+    def write_desktop(image)
       File.open(desktop_image_path, 'w') do |desktop|
         desktop.write image.data
       end
     end
 
-    def clear_custom_desktop_image
+    def save_image_path_in_database
       db = Database.new
       db.clear_desktop_image
+      db.set_desktop_image desktop_image_path
       db.close
-    end
-
-    def touch_desktop_image
-      unless system("touch -h #{desktop_image_path} 2>/dev/null")
-        raise Errno::EACCES
-      end
-    end
-
-    def remove_cached_image
-      system "rm #{cached_image_path} 2>/dev/null"
     end
 
     def reload_desktop
       system 'killall Dock'
     end
 
-    def default_cached_image_path
-      '/Library/Caches/com.apple.desktop.admin.png'
-    end
-
     def default_desktop_image_path
-      '/System/Library/CoreServices/DefaultDesktop.jpg'
+      File.expand_path "~/Library/Application Support/desktop-gem-wallpaper.jpg"
     end
   end
 end

--- a/lib/desktop/version.rb
+++ b/lib/desktop/version.rb
@@ -1,3 +1,3 @@
 module Desktop
-  VERSION = '1.2.0'
+  VERSION = '1.3.0.pre'
 end

--- a/test/desktop/cli_test.rb
+++ b/test/desktop/cli_test.rb
@@ -8,37 +8,31 @@ module Desktop
       desktop.write 'Default content'
       desktop.rewind
 
-      cached = Tempfile.new(%w[cached .jpg])
-      cached.write 'Cached content'
-      cached.rewind
-
       image = Tempfile.new(%w[image .jpg])
       image.write 'New content'
       image.rewind
 
       defaults = [
         "--desktop-image-path=#{desktop.path}",
-        "--cached-image-path=#{cached.path}",
         "--skip-reload",
         "--skip-database"
       ]
 
-      yield desktop, cached, image, defaults
+      yield desktop, image, defaults
     ensure
       desktop.unlink
-      cached.unlink
       image.unlink
     end
 
     it 'sets the desktop when a local image path is provided' do
-      with_defaults do |desktop, _, image, defaults|
+      with_defaults do |desktop, image, defaults|
         CLI.start ['set', image.path] + defaults
         assert_equal File.read(desktop), File.read(image)
       end
     end
 
     it 'sets the desktop when a web url is provided' do
-      with_defaults do |desktop, _, _, defaults|
+      with_defaults do |desktop, _, defaults|
         VCR.use_cassette('web_image_data') do
           CLI.start ['set', 'http://f.cl.ly/image.jpg'] + defaults
           refute_equal 'Default content', File.read(desktop)

--- a/test/desktop/osx/database_test.rb
+++ b/test/desktop/osx/database_test.rb
@@ -5,14 +5,16 @@ module Desktop
   describe OSX::Database do
     def with_connection
       connection = SQLite3::Database.new ':memory:'
-      yield connection
+      desktop_image = Tempfile.new(%w[desktop .jpg])
+      yield connection, desktop_image.path
     ensure
+      desktop_image.unlink
       connection.close
     end
 
     describe '#clear_desktop_image' do
       it 'clears contents of data table' do
-        with_connection do |connection|
+        with_connection do |connection, _|
           connection.execute("CREATE TABLE data (FileName STRING)")
           connection.execute("INSERT INTO data VALUES ('mydesktop.png')")
 
@@ -25,12 +27,37 @@ module Desktop
       end
 
       it 'does not blow up if data table does not exist' do
-        with_connection do |connection|
+        with_connection do |connection, _|
           assert_empty connection.execute(
             "SELECT name FROM sqlite_master WHERE type='table' AND name='data'"
           )
 
           OSX::Database.new(connection).clear_desktop_image
+        end
+      end
+    end
+
+    describe '#set_desktop_image' do
+      it 'fills the data table with entries for the new desktop image' do
+        with_connection do |connection, desktop_image_path|
+          connection.execute("CREATE TABLE data (value)")
+
+          assert_empty connection.execute("SELECT * FROM data")
+
+          OSX::Database.new(connection).set_desktop_image(desktop_image_path)
+
+          assert_equal [[desktop_image_path]] * 100,
+            connection.execute("SELECT * FROM data")
+        end
+      end
+
+      it 'does not blow up if data table does not exist' do
+        with_connection do |connection, desktop_image_path|
+          assert_empty connection.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='data'"
+          )
+
+          OSX::Database.new(connection).set_desktop_image(desktop_image_path)
         end
       end
     end

--- a/test/desktop/osx/osx_test.rb
+++ b/test/desktop/osx/osx_test.rb
@@ -6,43 +6,23 @@ module Desktop
   describe OSX do
     def osx
       desktop = Tempfile.new(%w[desktop .jpg])
-      cached  = Tempfile.new(%w[cached .jpg])
       image   = Tempfile.new(%w[image .jpg])
 
       osx = OSX.new(
         :desktop_image_path => desktop.path,
-        :cached_image_path  => cached.path,
         :skip_reload        => true,
         :skip_database      => true
       )
 
-      yield osx, desktop, cached, image
+      yield osx, desktop, image
     ensure
       desktop.unlink
-      cached.unlink
       image.unlink
     end
 
     describe '#desktop_image=' do
-      it 'removes the cached desktop image' do
-        osx do |osx, _, cached, image|
-          osx.desktop_image = LocalImage.new(image)
-          refute File.exists?(cached.path)
-        end
-      end
-
-      it 'raises DesktopImagePermissionsError when desktop is readonly' do
-        osx do |osx, desktop, _, image|
-          FileUtils.chmod 'a-w', desktop
-
-          assert_raises OSX::DesktopImagePermissionsError do
-            osx.desktop_image = LocalImage.new(image)
-          end
-        end
-      end
-
       it 'raises DesktopImageMissingError when new image is missing' do
-        osx do |osx, _, _, _|
+        osx do |osx, _, _|
           assert_raises OSX::DesktopImageMissingError do
             osx.desktop_image = LocalImage.new('/invalid/image/path.jpg')
           end


### PR DESCRIPTION
Fixes https://github.com/chrishunt/desktop/issues/28. 

We can no longer update the Mac OS X default desktop image because it's protected by the mighty [El Capitan SIP](https://developer.apple.com/library/prerelease/mac/releasenotes/MacOSX/WhatsNewInOSX/Articles/MacOSX10_11.html#//apple_ref/doc/uid/TP40016227-DontLinkElementID_17). This PR makes it so that we write our desktop image to `Application Support` instead.

You can test this pre-release with:

``` bash
$ gem update desktop --pre
```
